### PR TITLE
Centos: added as variant

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,3 +6,4 @@ services:
 script:
 - docker build .
 - docker build -f Dockerfile-alpine .
+- docker build -f Dockerfile-centos .

--- a/Dockerfile-alpine
+++ b/Dockerfile-alpine
@@ -1,5 +1,5 @@
 FROM alpine:3.4
-MAINTAINER Bryan Latten <latten@adobe.com>
+LABEL Maintainer="Bryan Latten <latten@adobe.com>"
 
 # Use in multi-phase builds, when an init process requests for the container to gracefully exit, so that it may be committed
 # Used with alternative CMD (worker.sh), leverages supervisor to maintain long-running processes
@@ -8,7 +8,10 @@ ENV SIGNAL_BUILD_STOP=99 \
     S6_KILL_FINISH_MAXTIME=5000 \
     S6_KILL_GRACETIME=3000 \
     S6_VERSION=v1.18.1.5 \
-    GOSS_VERSION=v0.2.3
+    GOSS_VERSION=v0.2.5
+
+# Ensure scripts are available for use in next command
+COPY ./container/root/scripts/* /scripts/
 
 RUN echo '@edge http://dl-cdn.alpinelinux.org/alpine/edge/testing' >> /etc/apk/repositories && \
     apk update && \

--- a/Dockerfile-centos
+++ b/Dockerfile-centos
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM centos:7
 LABEL Maintainer="Bryan Latten <latten@adobe.com>"
 
 # Use in multi-phase builds, when an init process requests for the container to gracefully exit, so that it may be committed
@@ -17,24 +17,16 @@ COPY ./container/root/scripts/* /scripts/
 # - Upgrade base security packages, then clean packaging leftover
 # - Add S6 for zombie reaping, boot-time coordination, signal transformation/distribution: @see https://github.com/just-containers/s6-overlay#known-issues-and-workarounds
 # - Add goss for local, serverspec-like testing
-RUN ln -s /scripts/clean_ubuntu.sh /clean.sh && \
-    ln -s /scripts/security_updates_ubuntu.sh /security_updates.sh && \
-    echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections && \
+RUN ln -s /scripts/clean_centos.sh /clean.sh && \
+    ln -s /scripts/security_updates_centos.sh /security_updates.sh && \
     /bin/bash -e /security_updates.sh && \
-    apt-get install -yqq \
-      curl \
-    && \
-    # Add S6 for zombie reaping, boot-time coordination, signal transformation/distribution
+    /bin/bash -e /clean.sh && \
     curl -L https://github.com/just-containers/s6-overlay/releases/download/${S6_VERSION}/s6-overlay-amd64.tar.gz -o /tmp/s6.tar.gz && \
-    tar xzf /tmp/s6.tar.gz -C / && \
-    rm /tmp/s6.tar.gz && \
-    # Add goss for local, serverspec-like testing
+    tar xzf /tmp/s6.tar.gz -C / --exclude="./bin" --exclude="./sbin" && \
+    tar xzf /tmp/s6.tar.gz -C /usr ./bin ./sbin && \
+    rm -f /tmp/s6.tar.gz && \
     curl -L https://github.com/aelsabbahy/goss/releases/download/${GOSS_VERSION}/goss-linux-amd64 -o /usr/local/bin/goss && \
-    chmod +x /usr/local/bin/goss && \
-    apt-get remove --purge -yq \
-        curl \
-    && \
-    /bin/bash -e /clean.sh
+    chmod +x /usr/local/bin/goss
 
 # Overlay the root filesystem from this repo
 COPY ./container/root /

--- a/README.md
+++ b/README.md
@@ -5,13 +5,21 @@
 
 https://hub.docker.com/r/behance/docker-base/tags/
 
-Ubuntu used by default, Alpine builds also available tagged as `-alpine`  
+Provides base OS, security patches, and tools for quick and easy spinup.  
 
-Provides base OS, patches and stable nginx for quick and easy spinup.  
 
-[S6](https://github.com/just-containers/s6-overlay) process supervisor is used for `only` for zombie reaping (as PID 1), boot coordination, and termination signal translation  
+### Variants  
 
-[Goss](https://github.com/aelsabbahy/goss) is used for build-time testing  
+Ubuntu container OS is in use by default  
+
+— Alpine builds available tagged as `-alpine`  
+— Centos builds available tagged as `-centos`
+
+
+### Tools
+
+- [S6](https://github.com/just-containers/s6-overlay) process supervisor is used for `only` for zombie reaping (as PID 1), boot coordination, and termination signal translation  
+- [Goss](https://github.com/aelsabbahy/goss) is used for build-time testing  
 
 ### Expectations
 
@@ -20,8 +28,21 @@ For programmatic switches, create the service in `/etc/services-available`, and 
 
 ### Security
 
-For Ubuntu-based variants, a convenience script is provided for security-only package updates. To run: 
-`/bin/bash -e /security_updates.sh`  
+A convenience script is provided for security-only package updates. 
+
+On Ubuntu and CentOS-based variants, run: 
+```/bin/bash -e /security_updates.sh```
+
+This file is actually a symlink to the variant-specific script contained in the `/scripts` folder
+
+### Packaging
+
+A convenience script is provided for post-package installation cleanup
+
+On Ubuntu and CentOS-based variants, run: 
+```/bin/bash -e /clean.sh```
+
+This file, like security_updates (above) is actually a symlink to the variant-specific script contained in the `/scripts` folder
 
 
 ### Environment Variables
@@ -75,3 +96,4 @@ Directory | Use
 `/etc/services.d/` |  services that will be supervised by S6: https://github.com/just-containers/s6-overlay#writing-a-service-script
 `/etc/services-available/` | same as above, but must be symlinked into `/etc/services.d/` to take effect
 `/run.d/` | shell scripts (ending in .sh) that make runtime modifications ahead of S6 initialization
+`/scripts` | convenience scripts that can be leveraged in derived images

--- a/container/root/scripts/clean_centos.sh
+++ b/container/root/scripts/clean_centos.sh
@@ -1,0 +1,10 @@
+#!/bin/bash -e
+
+# --- Centos variant only, for other variants, see /scripts folder
+
+#-------------------------------------------------------------------
+# Performs cleanup, ensure unnecessary packages and package lists
+# are safely removed, without triggering Docker AUFS permission bug
+#-------------------------------------------------------------------
+
+yum clean all

--- a/container/root/scripts/clean_ubuntu.sh
+++ b/container/root/scripts/clean_ubuntu.sh
@@ -1,5 +1,7 @@
 #!/bin/bash -e
 
+# --- Ubuntu variant only, for other variants, see /scripts folder
+
 #-------------------------------------------------------------------
 # Performs cleanup, ensure unnecessary packages and package lists
 # are safely removed, without triggering Docker AUFS permission bug

--- a/container/root/scripts/security_updates_centos.sh
+++ b/container/root/scripts/security_updates_centos.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# --- Centos variant only, for other variants, see /scripts folder
+
+#-------------------------------------------------------------------
+# Upgrade just the packages listed as security, without affecting
+# any subsequent usages of yum
+#-------------------------------------------------------------------
+
+yum -y update --security

--- a/container/root/scripts/security_updates_ubuntu.sh
+++ b/container/root/scripts/security_updates_ubuntu.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+# --- Ubuntu variant only, for other variants, see /scripts folder
+
 #-------------------------------------------------------------------
 # Upgrade just the packages listed as security, without affecting
 # any subsequent usages of apt-get

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ ubuntu:
    - '8080:8080'
   environment:
     SERVER_LOG_MINIMAL: 1
-    SERVER_APP_NAME: docker-test
+    SERVER_APP_NAME: docker-test-ubuntu
     S6_KILL_FINISH_MAXTIME: 1
     S6_KILL_GRACETIME: 1
 alpine:
@@ -14,6 +14,16 @@ alpine:
    - '8081:8080'
   environment:
     SERVER_LOG_MINIMAL: 1
-    SERVER_APP_NAME: docker-test
+    SERVER_APP_NAME: docker-test-alpine
+    S6_KILL_FINISH_MAXTIME: 1
+    S6_KILL_GRACETIME: 1
+centos:
+  build: .
+  dockerfile: Dockerfile-centos
+  ports:
+   - '8082:8080'
+  environment:
+    SERVER_LOG_MINIMAL: 1
+    SERVER_APP_NAME: docker-test-centos
     S6_KILL_FINISH_MAXTIME: 1
     S6_KILL_GRACETIME: 1


### PR DESCRIPTION
- Added tests for new variant of CentOS
- Swapped deprecated `MAINTAINER` tag for `LABEL`
- Standardized GOSS versions across the board
- Made variant-specific security and clean scripts, symlinked variant's into original place
