### PR TITLE
Enable dependent builds to get newes security updates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,6 +42,8 @@ COPY ./container/root /
 
 RUN goss -g goss.base.yaml validate
 
+ONBUILD RUN /bin/bash -e /security_updates.sh && /bin/bash -e /clean.sh
+
 # NOTE: intentionally NOT using s6 init as the entrypoint
 # This would prevent container debugging if any of those service crash
 CMD ["/bin/bash", "/run.sh"]

--- a/Dockerfile-alpine
+++ b/Dockerfile-alpine
@@ -39,6 +39,8 @@ RUN ln -s /scripts/clean_alpine.sh /clean.sh && \
 # Overlay the root filesystem from this repo
 COPY ./container/root /
 
+ONBUILD RUN apk update && apk upgrade && /bin/bash -e /clean.sh
+
 RUN goss -g goss.base.yaml validate
 
 # NOTE: intentionally NOT using s6 init as the entrypoint

--- a/Dockerfile-centos
+++ b/Dockerfile-centos
@@ -31,6 +31,8 @@ RUN ln -s /scripts/clean_centos.sh /clean.sh && \
 # Overlay the root filesystem from this repo
 COPY ./container/root /
 
+ONBUILD RUN /bin/bash -e /security_updates.sh && /bin/bash -e /clean.sh
+
 RUN goss -g goss.base.yaml validate
 
 # NOTE: intentionally NOT using s6 init as the entrypoint


### PR DESCRIPTION
Enables dependent images to get newest security updates upon building their image.
Will not force dependent images to update the packages on their own but instead provides an easy way to define this in the base image.

Documentation: https://docs.docker.com/engine/reference/builder/#onbuild

This will not inherit to all but the direct children of this image.

Example:
```
Sending build context to Docker daemon 43.01 kB
Step 1/1 : FROM docker-base
# Executing 1 build trigger...
Step 1/1 : RUN /bin/bash -e /security_updates.sh && /bin/bash -e /clean.sh
 ---> Running in 806eacbb4597
Hit:1 http://archive.ubuntu.com/ubuntu xenial InRelease
Hit:2 http://archive.ubuntu.com/ubuntu xenial-updates InRelease
Hit:3 http://archive.ubuntu.com/ubuntu xenial-security InRelease
Get:4 http://archive.ubuntu.com/ubuntu xenial/main Sources [1103 kB]
Get:5 http://archive.ubuntu.com/ubuntu xenial/restricted Sources [5179 B]
Get:6 http://archive.ubuntu.com/ubuntu xenial/universe Sources [9802 kB]
Get:7 http://archive.ubuntu.com/ubuntu xenial/main amd64 Packages [1558 kB]
Get:8 http://archive.ubuntu.com/ubuntu xenial/restricted amd64 Packages [14.1 kB]
Get:9 http://archive.ubuntu.com/ubuntu xenial/universe amd64 Packages [9827 kB]
Get:10 http://archive.ubuntu.com/ubuntu xenial-updates/main Sources [312 kB]
Get:11 http://archive.ubuntu.com/ubuntu xenial-updates/restricted Sources [3202 B]
...
```