### PR TITLE
create nsswitch.conf file to resolve unknownhost exception issue

### DIFF
--- a/Dockerfile-alpine
+++ b/Dockerfile-alpine
@@ -30,6 +30,8 @@ RUN ln -s /scripts/clean_alpine.sh /clean.sh && \
     curl -L https://github.com/just-containers/s6-overlay/releases/download/${S6_VERSION}/s6-overlay-amd64.tar.gz -o /tmp/s6.tar.gz && \
     tar xzf /tmp/s6.tar.gz -C / && \
     rm /tmp/s6.tar.gz && \
+    # https://github.com/gliderlabs/docker-alpine/issues/11#issuecomment-106233554
+    echo 'hosts: files mdns4_minimal [NOTFOUND=return] dns mdns4' > /etc/nsswitch.conf && \
     # Add goss for local, serverspec-like testing \
     curl -L https://github.com/aelsabbahy/goss/releases/download/${GOSS_VERSION}/goss-linux-amd64 -o /usr/local/bin/goss && \
     chmod +x /usr/local/bin/goss && \


### PR DESCRIPTION
In absence of /etc/nsswitch.conf file it uses /etc/hosts (file) or /etc/resolv.conf (dns) to resolve hostname. Using /etc/nsswitch.conf we can define the order in which host name resolution should be done. More details on the following [blog](https://community.hpe.com/t5/System-Administration/nsswitch-conf/m-p/3815887/highlight/true#M269190).

On looking further into this issue some folks have also reported similar issue in java+alpine combo and here is the suggested fix.
 - http://arthur-c.github.io/posts/alpine-linux-java-unknownhostexception/
 - http://stackoverflow.com/questions/32537977/java-net-unknownhostexception-on-docker?answertab=votes#tab-top
 - https://github.com/gliderlabs/docker-alpine/issues/11#issuecomment-91329401
 - https://github.com/gliderlabs/docker-alpine/issues/11#issuecomment-106233554
 
Basically we need to write /etc/nsswitch.conf file with following entry.
```
hosts: files mdns4_minimal [NOTFOUND=return] dns mdns4
```

To understand the exact meaning of the above line you can read [here](https://ubuntuforums.org/showthread.php?t=971693&p=12589927#post12589927)
Some more details on nsswitch.conf file is available [here](http://man7.org/linux/man-pages/man5/nsswitch.conf.5.html).