### PR TITLE
adding regex to filter out env var names which bash does not like

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Ubuntu container OS is in use by default
 
 - [S6](https://github.com/just-containers/s6-overlay) process supervisor is used for `only` for zombie reaping (as PID 1), boot coordination, and termination signal translation  
 - [Goss](https://github.com/aelsabbahy/goss) is used for build-time testing  
+- [Dgoss](https://github.com/aelsabbahy/goss/tree/master/extras/dgoss) is used for run-time testing.
 
 ### Expectations
 
@@ -63,8 +64,8 @@ As part of the process manager, these scripts are run in advance of the supervis
 
 ### Testing
 
-Container tests itself as part of build process using [goss](https://github.com/aelsabbahy/goss) validator. 
-To add additional tests, overwrite (or extend) the `/goss.base.yaml` file.  
+- Container tests itself as part of build process using [goss](https://github.com/aelsabbahy/goss) validator. To add additional build-time tests, overwrite (or extend) the `./container/root/goss.base.yaml` file.
+- To initiate run-time validation, please execute `test.sh`. It uses [dgoss](https://github.com/aelsabbahy/goss/tree/master/extras/dgoss) validator. To add additional run-time tests, extend `./test.sh` and `./goss.yaml` file.
 
 
 

--- a/container/root/scripts/with-bigcontenv
+++ b/container/root/scripts/with-bigcontenv
@@ -9,10 +9,11 @@
 #-------------------------------------------------------------------
 
 CONTAINER_ENV_LOC=/var/run/s6/container_environment/*
+VALID_ENVNAME_REGEX="^[[:alpha:]_][[:alnum:]_]*$"
 
 for f in $CONTAINER_ENV_LOC; do
   env_variable_name="${f##*/}"
-  if [ "${env_variable_name}" != "UID" ] && [ "${env_variable_name}" != "!" ]; then
+  if [ "${env_variable_name}" != "UID" ] && [[ ${env_variable_name} =~ $VALID_ENVNAME_REGEX ]]; then
     export "${env_variable_name}"="`cat $f`"
   fi
 done

--- a/container/root/scripts/with-bigcontenv
+++ b/container/root/scripts/with-bigcontenv
@@ -13,7 +13,7 @@ VALID_ENVNAME_REGEX="^[[:alpha:]_][[:alnum:]_]*$"
 
 for f in $CONTAINER_ENV_LOC; do
   env_variable_name="${f##*/}"
-  if [ "${env_variable_name}" != "UID" ] && [[ ${env_variable_name} =~ $VALID_ENVNAME_REGEX ]]; then
+  if [[ "${env_variable_name}" != "UID" ]] && [[ ${env_variable_name} =~ ${VALID_ENVNAME_REGEX} ]]; then
     export "${env_variable_name}"="`cat $f`"
   fi
 done

--- a/test.sh
+++ b/test.sh
@@ -18,7 +18,7 @@ for x in Dockerfile*;do
   echo "======================="
   docker build -t runtimetestimage -f "${x}" .
   #passes an env variable of size more than 4K chars
-  time dgoss run -v `pwd`/test_scripts:/test_scripts -e TEST_LONG_VAR="${largevar}" -e 1VAR_NAME=varnameStartWithNumber -e var.name=varnameHasPeriod -e var-name=varnameHasHyphen -e _=varnameHasJustUnderscore runtimetestimage || ((i++))
+  time dgoss run -v `pwd`/test_scripts:/test_scripts -e TEST_LONG_VAR="${largevar}" -e 1VAR_NAME=varnameStartWithNumber -e var.name=varnameHasPeriod -e var-name=varnameHasHyphen runtimetestimage || ((i++))
 done
 
 exit $i

--- a/test.sh
+++ b/test.sh
@@ -18,7 +18,7 @@ for x in Dockerfile*;do
   echo "======================="
   docker build -t runtimetestimage -f "${x}" .
   #passes an env variable of size more than 4K chars
-  time dgoss run -v `pwd`/test_scripts:/test_scripts -e TEST_LONG_VAR="${largevar}" runtimetestimage || ((i++))
+  time dgoss run -v `pwd`/test_scripts:/test_scripts -e TEST_LONG_VAR="${largevar}" -e 1VAR_NAME=varnameStartWithNumber -e var.name=varnameHasPeriod -e var-name=varnameHasHyphen -e _=varnameHasJustUnderscore runtimetestimage || ((i++))
 done
 
 exit $i


### PR DESCRIPTION
- Updated variable name filter in `with-bigcontenv` script before exporting them. We needed to update this because ```Environment variable names used by the utilities in the Shell and Utilities volume of IEEE Std 1003.1-2001 consist solely of uppercase letters, digits, and the '_' (underscore) from the characters defined in Portable Character Set and do not begin with a digit. Other characters may be permitted by an implementation; applications shall tolerate the presence of such names. Uppercase and lowercase letters shall retain their unique identities and shall not be folded together. The name space of environment variable names containing lowercase letters is reserved for applications. Applications can define any environment variables with names from this name space without modifying the behavior of the standard utilities.```
[Opengroup link](http://pubs.opengroup.org/onlinepubs/000095399/basedefs/xbd_chap08.html)
[Stackoverflow link](https://stackoverflow.com/questions/2821043/allowed-characters-in-linux-environment-variable-names)
- Also added env variable names to dgoss test which can't be exported using `with-bigcontenv`. The updated script filters the env variable name before exporting them. This will test if the script crashes when it finds a variable name which is not compatible with bash