### PR TITLE
Removing systemd binary for CVE-2017-1000082

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,7 @@ RUN /bin/bash -e /scripts/ubuntu_apt_cleanmode.sh && \
         curl \
     && \
     /bin/bash -e /clean.sh && \
-    # To remove systemd binary
+    # out of order execution, has a dpkg error if performed before the clean script, so keeping it here,
     apt-get remove --purge --auto-remove systemd --allow-remove-essential -y
 
 # Overlay the root filesystem from this repo

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,6 +36,7 @@ RUN /bin/bash -e /scripts/ubuntu_apt_cleanmode.sh && \
         curl \
     && \
     /bin/bash -e /clean.sh && \
+    # To remove systemd binary
     apt-get remove --purge --auto-remove systemd --allow-remove-essential -y
 
 # Overlay the root filesystem from this repo

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,8 @@ RUN /bin/bash -e /scripts/ubuntu_apt_cleanmode.sh && \
     apt-get remove --purge -yq \
         curl \
     && \
-    /bin/bash -e /clean.sh
+    /bin/bash -e /clean.sh && \
+    apt-get remove --purge --auto-remove systemd --allow-remove-essential -y
 
 # Overlay the root filesystem from this repo
 COPY ./container/root /

--- a/Dockerfile-centos
+++ b/Dockerfile-centos
@@ -20,6 +20,7 @@ COPY ./container/root/scripts/* /scripts/
 RUN ln -s /scripts/clean_centos.sh /clean.sh && \
     ln -s /scripts/security_updates_centos.sh /security_updates.sh && \
     /bin/bash -e /security_updates.sh && \
+    rpm -e systemd --nodeps && \
     /bin/bash -e /clean.sh && \
     curl -L https://github.com/just-containers/s6-overlay/releases/download/${S6_VERSION}/s6-overlay-amd64.tar.gz -o /tmp/s6.tar.gz && \
     tar xzf /tmp/s6.tar.gz -C / --exclude="./bin" && \


### PR DESCRIPTION
`systemd` binary is copying from ubuntu:16.04 and causing the CVE 
```
"file": "systemd",
"filetype": "package",
"name": "CVE-2017-1000082",
"type": "",
"description": "systemd v233 and earlier fails to safely parse usernames starting with a numeric digit (e.g. \"0day\"), running the service in question with root privileges rather than the user intended.",
"score": 10,
```
Note: ubuntu:17.04 and ubuntu:17.10 doesn't include the `systemd` binary