### PR TITLE
Upgrade ubuntu version from 18.04 to 18.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,5 +11,5 @@ script:
 - docker build .
 - docker build -f Dockerfile-alpine .
 - docker build -f Dockerfile-centos .
-- docker build -f Dockerfile-ubuntu-18.04 .
+- docker build -f Dockerfile-ubuntu-18.10 .
 - ./test.sh

--- a/Dockerfile-ubuntu-18.10
+++ b/Dockerfile-ubuntu-18.10
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04 as base
+FROM ubuntu:18.10 as base
 
 ### Stage 1 - add/remove packages ###
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Provides base OS, security patches, and tools for quick and easy spinup.
 ### Variants  
 
 — Ubuntu 16.04 LTS is default  
-— Ubuntu 18.04 available, tagged as `-VERSION#-ubuntu-18.04`  
+— Ubuntu 18.10 available, tagged as `-VERSION#-ubuntu-18.10`
 — Alpine builds available, tagged as `-alpine`  
 — Centos builds available, tagged as `-centos`  
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,11 +39,11 @@ ubuntu17:
     S6_KILL_GRACETIME: 1
 ubuntu18:
   build: .
-  dockerfile: Dockerfile-ubuntu-18.04
+  dockerfile: Dockerfile-ubuntu-18.10
   ports:
    - '8084:8080'
   environment:
     SERVER_LOG_MINIMAL: 1
-    SERVER_APP_NAME: docker-test-ubuntu-18.04
+    SERVER_APP_NAME: docker-test-ubuntu-18.10
     S6_KILL_FINISH_MAXTIME: 1
     S6_KILL_GRACETIME: 1


### PR DESCRIPTION
## Summary
Upgrade ubuntu version from 18.04 to 18.10. Needed to resolve CVE for downstream nodejs BBCs: https://nvd.nist.gov/vuln/detail/CVE-2019-2130#vulnCurrentDescriptionTitle.

## Changes
- change name of `Dockerfile-ubuntu-18.04` -> `Dockerfile-ubuntu-18.10` 
- update FROM line: ubuntu:18.04 as base -> ubuntu:18.10 as base 
- update doc accordingly
- update yml files accordingly

## Testing
- Was able to build image using `Dockerfile-ubuntu-18.10` successfully