### PR TITLE
Update Dockerfile-ubuntu-18.04

### DIFF
--- a/Dockerfile-ubuntu-18.04
+++ b/Dockerfile-ubuntu-18.04
@@ -23,6 +23,7 @@ RUN /bin/bash -e /scripts/ubuntu_apt_cleanmode.sh && \
     apt-get remove --purge -yq \
         curl \
         gpg \
+        apt-transport-https \
     && \
     /bin/bash -e /clean.sh && \
     # out of order execution, has a dpkg error if performed before the clean script, so keeping it here,


### PR DESCRIPTION
Added the package apt-transport-https, which is required for https apt-get repos.