### PR TITLE
Alpine: Update docker-base from 3.14 to 3.15

### DIFF
--- a/Dockerfile-alpine
+++ b/Dockerfile-alpine
@@ -1,4 +1,4 @@
-FROM alpine:3.14 as base
+FROM alpine:3.15 as base
 
 ### Stage 1 - add/remove packages ###
 


### PR DESCRIPTION
@bryanlatten / @ko-be / @bossjones : Update Alpine from 3.14 to 3.15. Alpine 3.15 released Nov 24, 2021 [1], [2]

## Updated
- Update `FROM` version from `3.14` to `3.15` in `Dockerfile-alpine`

## Notes to self:

A few things I picked from [2] that might impact some of the downstream images:
* New signing keys have been increased fro 2k to 4k. Make sure you have alpine-keys-2.4-r0 or later before upgrading to 3.15 (or downgrading from edge). 
* nodejs LTS upgraded to version 16.13.0

[1] https://alpinelinux.org/posts/Alpine-3.15.0-released.html
[2] https://wiki.alpinelinux.org/wiki/Release_Notes_for_Alpine_3.15.0