### PR TITLE
Add Ubuntu 22.04

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,6 +22,8 @@ jobs:
           suffix: ubuntu-18.04
         - Dockerfile: Dockerfile-ubuntu-20.04
           suffix: ubuntu-20.04
+        - Dockerfile: Dockerfile-ubuntu-22.04
+          suffix: ubuntu-22.04
         - Dockerfile: Dockerfile-alpine
           suffix: alpine
         - Dockerfile: Dockerfile-centos-7

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,13 +7,18 @@ before_install:
 # install goss
 - curl -L https://goss.rocks/install | sudo sh
 
+os: linux
+
+dist: focal
+
 arch:
   - amd64
-  - arm64
+  - arm64-graviton2
 
 script:
 - docker build -f Dockerfile-alpine .
 - docker build -f Dockerfile-centos-7 .
 - docker build -f Dockerfile-ubuntu-18.04 .
 - docker build -f Dockerfile-ubuntu-20.04 .
+- docker build -f Dockerfile-ubuntu-22.04 .
 - ./test.sh

--- a/Dockerfile-ubuntu-22.04
+++ b/Dockerfile-ubuntu-22.04
@@ -1,0 +1,52 @@
+FROM ubuntu:22.04 as base
+
+### Stage 1 - add/remove packages ###
+
+# Ensure scripts are available for use in next command
+COPY ./container/root/scripts/* /scripts/
+COPY ./container/root/usr/local/bin/* /usr/local/bin/
+
+# - Symlink variant-specific scripts to default location
+# - Upgrade base security packages, then clean packaging leftover
+# - Add S6 for zombie reaping, boot-time coordination, signal transformation/distribution: @see https://github.com/just-containers/s6-overlay#known-issues-and-workarounds
+# - Add goss for local, serverspec-like testing
+RUN /bin/bash -e /scripts/ubuntu_apt_config.sh && \
+    /bin/bash -e /scripts/ubuntu_apt_cleanmode.sh && \
+    ln -s /scripts/clean_ubuntu.sh /clean.sh && \
+    ln -s /scripts/security_updates_ubuntu.sh /security_updates.sh && \
+    echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections && \
+    /bin/bash -e /security_updates.sh && \
+    apt-get install -yqq \
+      curl \
+      gpg \
+      apt-transport-https \
+    && \
+    /bin/bash -e /scripts/install_s6.sh && \
+    /bin/bash -e /scripts/install_goss.sh && \
+    apt-get remove --purge -yq \
+        curl \
+        gpg \
+    && \
+    /bin/bash -e /clean.sh
+
+# Overlay the root filesystem from this repo
+COPY ./container/root /
+
+
+### Stage 2 --- collapse layers ###
+
+FROM scratch
+COPY --from=base / .
+
+# Use in multi-phase builds, when an init process requests for the container to gracefully exit, so that it may be committed
+# Used with alternative CMD (worker.sh), leverages supervisor to maintain long-running processes
+ENV SIGNAL_BUILD_STOP=99 \
+    S6_BEHAVIOUR_IF_STAGE2_FAILS=2 \
+    S6_KILL_FINISH_MAXTIME=5000 \
+    S6_KILL_GRACETIME=3000
+
+RUN goss -g goss.base.yaml validate
+
+# NOTE: intentionally NOT using s6 init as the entrypoint
+# This would prevent container debugging if any of those service crash
+CMD ["/bin/bash", "/run.sh"]

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Provides base OS, security patches, and tools for quick and easy spinup.
 
 * Ubuntu 18.04 LTS available, tagged as `-VERSION#-ubuntu-18.04`
 * Ubuntu 20.04 LTS available, tagged as `-VERSION#-ubuntu-20.04`
+* Ubuntu 22.04 LTS available, tagged as `-VERSION#-ubuntu-22.04`
 * Alpine builds available, tagged as `-alpine`
 * Centos 7 builds available, tagged as `-centos-7`
 


### PR DESCRIPTION
Add Ubuntu 22.04 LTS base image.

Switch Travis environment from the default Ubuntu 16.04 (Xenial) (which is EOL as of last year) to Ubuntu 20.04 (Focal) and switch arm64 builds from arm64 LXD to arm64-graviton as Travis CI builds were otherwise failing.

Reference:
- https://docs.travis-ci.com/user/reference/overview/#virtualization-environments
- https://docs.travis-ci.com/user/reference/overview/#linux-travisyml-examples

