### PR TITLE
S6: rolling back to earlier 2.x release

### DIFF
--- a/container/root/scripts/install_goss.sh
+++ b/container/root/scripts/install_goss.sh
@@ -6,7 +6,7 @@
 # Downloads, verifies, and installs
 # Requires curl and sha256sum to be present
 
-GOSS_VERSION=v0.3.16
+GOSS_VERSION=${GOSS_VERSION:="v0.3.16"}
 
 # Locate manually and commit below from https://github.com/aelsabbahy/goss/releases/download/${GOSS_VERSION}/goss-linux-${ARCH}.sha256
 # Determined automatically to correctly select binary

--- a/container/root/scripts/install_s6.sh
+++ b/container/root/scripts/install_s6.sh
@@ -10,7 +10,7 @@
 ARCH="$(archstring --x64 amd64 --arm64 aarch64)"
 
 S6_NAME=s6-overlay-${ARCH}.tar.gz
-S6_VERSION=v2.2.0.3
+S6_VERSION=${S6_VERSION:="v2.1.0.2"}
 PUBLIC_KEY=6101B2783B2FD161
 
 curl -fL https://github.com/just-containers/s6-overlay/releases/download/${S6_VERSION}/${S6_NAME} -o /tmp/${S6_NAME}


### PR DESCRIPTION
- Regression found: https://github.com/just-containers/s6-overlay/issues/363
- (bonus) Goss/S6: allowing ENV override for install script

Replaces PR https://github.com/behance/docker-base/pull/68