### PR TITLE
feat: force yum update for CentOS and deprecate Alpine/CentOS variants

### DIFF
--- a/Dockerfile-alpine
+++ b/Dockerfile-alpine
@@ -1,3 +1,7 @@
+################################################################################
+# The AlpineOS flavor is DEPRECATED and will be removed in a future release
+# Please stop using this variant and use the Ubuntu flavor instead
+################################################################################
 FROM alpine:3.15 as base
 
 ### Stage 1 - add/remove packages ###

--- a/Dockerfile-centos-7
+++ b/Dockerfile-centos-7
@@ -1,3 +1,7 @@
+################################################################################
+# The CentOS flavor is DEPRECATED and will be removed in a future release
+# Please stop using this variant and use the Ubuntu flavor instead
+################################################################################
 FROM centos:7 as base
 
 ### Stage 1 - add/remove packages ###
@@ -14,6 +18,7 @@ RUN ln -s /scripts/clean_centos.sh /clean.sh && \
     ln -s /scripts/security_updates_centos.sh /security_updates.sh && \
     /bin/bash -e /security_updates.sh && \
     rpm -e systemd --nodeps && \
+    yum -y update && \
     /bin/bash -e /clean.sh && \
     /bin/bash -e /scripts/install_s6.sh && \
     /bin/bash -e /scripts/install_goss.sh

--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ Provides base OS, security patches, and tools for quick and easy spinup.
 * Ubuntu 18.04 LTS available, tagged as `-VERSION#-ubuntu-18.04`
 * Ubuntu 20.04 LTS available, tagged as `-VERSION#-ubuntu-20.04`
 * Ubuntu 22.04 LTS available, tagged as `-VERSION#-ubuntu-22.04`
-* Alpine builds available, tagged as `-alpine`
-* Centos 7 builds available, tagged as `-centos-7`
+* Alpine builds available, tagged as `-alpine` **DEPRECATED**
+* Centos 7 builds available, tagged as `-centos-7` **DEPRECATED**
 
 ### Tools
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,63 @@
+# Troubleshooting
+
+* [gpg: keyserver receive failed: End of file](#gpg-keyserver-receive-failed-end-of-file)
+
+# gpg: keyserver receive failed: End of file
+
+There have been cases where the `install_s6.sh` script fails with:
+
+```
+#13 11.49 gpg: directory '/root/.gnupg' created
+#13 11.50 gpg: keybox '/root/.gnupg/pubring.kbx' created
+#13 15.49 gpg: keyserver receive failed: End of file
+#13 ERROR: process "/bin/sh -c ln -s /scripts/clean_alpine.sh /clean.sh
+[...snip...]
+```
+
+If you look at the `install_s6.sh` script, it fails on this line:
+
+```
+gpg --keyserver pgp.surfnet.nl --recv-keys $PUBLIC_KEY
+```
+
+If you try to manually run this command, it fails:
+
+```
+gpg --keyserver pgp.surfnet.nl --recv-keys 6101B2783B2FD161
+gpg: directory '/root/.gnupg' created
+gpg: keybox '/root/.gnupg/pubring.kbx' created
+gpg: keyserver receive failed: End of file
+root@dd54b59b57c5:/# echo $?
+2
+```
+
+As a workaround (for now), I found [#352] and in the comments, I found a
+solution from `mikenye` where he [embeds the actual public key].
+
+So if you're building locally and are runing into this failure try:
+
+1. Copy the public key from `mikenye`'s PR and save it as `s6-gpg-pub-key`
+1. Update the Dockerfile instructions to copy the file to `/tmp`
+   i.e. `COPY s6-gpg-pub-key /tmp/s6-gpg-pub-key`
+1. Update `install_s6.sh`. Instead of:
+   ```
+   gpg --keyserver pgp.surfnet.nl --recv-keys 6101B2783B2FD161
+   ```
+
+   You do:
+   ```
+   gpg --import /tmp/s6-gpg-pub-key
+   rm /tmp/s6-gpg-pub-key
+   ```
+1. The rest of the commands should be the same
+
+In more recent versions of s6-overlay i.e. `3.x`, it looks like their
+[verification steps] are different. So this could be a temporary issue
+until we upgrade to the latest s6-overlay version.
+
+If we're going to stay on this version for a while, we might just end up
+baking in the public key
+
+[#352]: https://github.com/just-containers/s6-overlay/issues/352
+[embeds the actual public key]: https://github.com/mikenye/deploy-s6-overlay/pull/10
+[verification steps]: https://github.com/just-containers/s6-overlay/#verifying-downloads


### PR DESCRIPTION
## Added
* Add step to do a full `yum -y update` to catch any non-security patches. See https://wiki.corp.adobe.com/x/K0Cwng for more details. Bottom line, `/security_updates.sh` does not fetch all of the packages since it does not treat them as "security updates" - ETHOS-38706
* Add troubleshooting steps for `gpg: keyserver receive failed: End of file` - ETHOS-38803

## Updated
* Add DEPRECATED notices on both `Alpine` and `CentOS` Dockerfiles. Will eventually remove in future versions.